### PR TITLE
CASMINST-3639: fix bash syntax error

### DIFF
--- a/bin/bios-baseline.sh
+++ b/bin/bios-baseline.sh
@@ -70,7 +70,7 @@ function ilo_config() {
 }
 
 function ilo_enable_ipmitool {
-    if ilorest --nologo rawpatch $HPE_IPMI_CONF 2&>1 >/dev/null; then
+    if ilorest --nologo rawpatch $HPE_IPMI_CONF > /dev/null 2>&1; then
         echo 'ipmitool usage: enabled'
     else
         echo 'could not enable DCMI/IPMI; ipmitool may not function!'


### PR DESCRIPTION
#### Summary and Scope

This script had 2&>1 instead of 2>&1, causing a file named `1`
to be created on every invocation.  Additionally, 2>&1 is technically
supposed to be the last thing in the statement.

<!--- Pick one below and delete the rest -->

- Fixes CASMINST-3639

##### Issue Type
<!--- Delete un-needed bullets -->

- Bugfix Pull Request