### PR TITLE
CASMINST-4061 change wicked ifreload to down and up

### DIFF
--- a/bin/csi-setup-lan0.sh
+++ b/bin/csi-setup-lan0.sh
@@ -20,7 +20,7 @@ sed -i 's/^BRIDGE_PORTS=.*/BRIDGE_PORTS="'"$*"'"/g' /etc/sysconfig/network/ifcfg
 echo "default $gateway - -" >/etc/sysconfig/network/ifroute-lan0
 sed -i 's/NETCONFIG_DNS_STATIC_SERVERS=.*/NETCONFIG_DNS_STATIC_SERVERS="'"${dns:-9.9.9.9}"'"/' /etc/sysconfig/network/config
 netconfig update -f
-wicked ifreload lan0
+wicked ifdown lan0 && wicked ifup lan0
 systemctl restart wickedd-nanny # Shake out daemon handling of new lan0 name.
 rDNS_FQDN=$(nslookup $addr - $(tail -n 1 /etc/resolv.conf | awk '{print $NF}') | awk '{print $NF}')
 rDNS=$(echo $rDNS_FQDN | cut -d '.' -f1)


### PR DESCRIPTION
Update to line 23 to replace wicked ifreload lan0 with wicked ifdown lan0 && wicked ifup lan0. Wicked by default looks at its /etc/wicked/common.xml to determine if there has been a change. If someone runs this script with invalid values, then re-runs it, wicked doens't see anything changed in common.xml, so it doesn't actually reload the interfaces. There doesn't seem seem to be a force flag option but this changed worked in vale in casminst-4061 to resolve the issue.

#### Summary and Scope


- Fixes #CASMINST-4061

##### Issue Type

- Bugfix Pull Request
- Docs Pull Request
- RFE Pull Request

modifies init script to use wicked ifdown/ifup instead of wicked reload to make the script repeatable/idempotent.
#### Prerequisites

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I tested this on internal system (x) (if yes, please include results or a description of the test)
 

#### Idempotency
 
done
 
#### Risks and Mitigations
 
What is less risky, or more risky now - or if your mod fails is there a new risk?
