### PR TITLE
Fix metadata for SLES15SP3

### DIFF
--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -1,5 +1,6 @@
 @Library('csm-shared-library') _
 
+def sleVersion = '15.3'
 def isStable = env.TAG_NAME != null || env.BRANCH_NAME == 'main' ? true : false
 pipeline {
   agent {
@@ -8,23 +9,39 @@ pipeline {
 
   options {
     buildDiscarder(logRotator(numToKeepStr: "10"))
+    disableConcurrentBuilds()
+    timeout(time: 20, unit: 'MINUTES')
     timestamps()
   }
 
   environment {
     BUILD_METADATA = getRpmRevision(isStable: isStable)
-    GIT_REPO_NAME = sh(returnStdout: true, script: "basename -s .git ${GIT_URL}").trim()
-
+    GIT_REPO_NAME = getRepoName()
   }
 
   stages {
-    stage('Prepare') {
+    stage("Prepare: RPM") {
+      agent {
+        docker {
+          label 'docker'
+          reuseNode true
+          image "artifactory.algol60.net/csm-docker/stable/csm-docker-sle:${sleVersion}"
+        }
+      }
       steps {
+        runLibraryScript("addRpmMetaData.sh", "${env.GIT_REPO_NAME}.spec")
         sh "make prepare"
       }
     }
 
     stage('Build: RPM') {
+      agent {
+        docker {
+          label 'docker'
+          reuseNode true
+          image "artifactory.algol60.net/csm-docker/stable/csm-docker-sle:${sleVersion}"
+        }
+      }
       steps {
         sh "make rpm"
       }


### PR DESCRIPTION
Right now pit-init is missing Git information from its package description and a value for its distribution:
```
Name        : pit-init
Version     : 1.2.23
Release     : 1
Architecture: noarch
Install Date: Wed 11 May 2022 04:05:26 PM UTC
Group       : Unspecified
Size        : 40048
License     : HPE Proprietary
Signature   : (none)
Source RPM  : pit-init-1.2.23-1.src.rpm
Build Date  : Mon 09 May 2022 10:55:26 PM UTC
Build Host  : csm-jenkins-metal-builder-q36mg2.us-central1-a.c.cloudbees-202004.internal
Relocations : (not relocatable)
Vendor      : Hewlett Packard Enterprise Development LP
Summary     : The pre-install toolkit scripts provided on the CRAY LiveCD
Description :

Distribution: (none)
```

This amends the description with git info while also setting the distribution value:
```
Description :
Git Repository: pit-init
Git Branch: metadata
Git Commit Revision: 93121188
Git Commit Timestamp: Fri May 20 17:02:49 2022 -0500
Distribution: SUSE Linux Enterprise Server 15 SP3
```