### PR TITLE
Publish RPMs to both dropoff locations

### DIFF
--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -50,8 +50,10 @@ pipeline {
     stage('Publish') {
       steps {
         script {
-          publishCsmRpms(component: env.GIT_REPO_NAME, pattern: "dist/rpmbuild/RPMS/noarch/*.rpm", arch: "noarch", isStable: isStable)
-          publishCsmRpms(component: env.GIT_REPO_NAME, pattern: "dist/rpmbuild/SRPMS/*.rpm", arch: "src", isStable: isStable)
+          publishCsmRpms(component: env.GIT_REPO_NAME, pattern: "dist/rpmbuild/RPMS/noarch/*.rpm", os: "sle-15sp2", arch: "noarch", isStable: isStable)
+          publishCsmRpms(component: env.GIT_REPO_NAME, pattern: "dist/rpmbuild/RPMS/noarch/*.rpm", os: "sle-15sp3git ", arch: "noarch", isStable: isStable)
+          publishCsmRpms(component: env.GIT_REPO_NAME, pattern: "dist/rpmbuild/SRPMS/*.rpm", os: "sle-15sp2", arch: "src", isStable: isStable)
+          publishCsmRpms(component: env.GIT_REPO_NAME, pattern: "dist/rpmbuild/SRPMS/*.rpm", os: "sle-15sp3", arch: "src", isStable: isStable)
         }
       }
     }


### PR DESCRIPTION
This just publishes RPMs to both locations:
- https://artifactory.algol60.net/ui/repos/tree/General/csm-rpms/sle-15sp2/
- https://artifactory.algol60.net/ui/repos/tree/General/csm-rpms/sle-15sp3/

Since the package is compatible with both distros, this removes the opportunity for any misconception while allowing zypper to pull the latest RPM all the same.