### PR TITLE
CASMINST-4884: add blacklisted modules to kernel command line on workers

### DIFF
--- a/bin/set-sqfs-links.sh
+++ b/bin/set-sqfs-links.sh
@@ -78,7 +78,7 @@ for ncn in $(grep -Eo 'ncn-[mw]\w+' /var/lib/misc/dnsmasq.leases | sort -u); do
     mkdir -pv ${ncn} && pushd ${ncn}
     cp -pv /var/www/boot/script.ipxe .
     if [[ "$ncn" =~ 'ncn-w' ]]; then
-        sed -i -E 's/rd.luks(=1)?\s/rd.luks=0 /g' script.ipxe
+        sed -i -E 's/rd.luks(=1)?\s/rd.luks=0 module_blacklist=rpcrdma /g' script.ipxe
     fi
     ln -vsnf ..${k8s_kernel///var\/www} kernel
     ln -vsnf ..${k8s_initrd///var\/www} initrd.img.xz


### PR DESCRIPTION
### Summary and Scope

Add the blacklisted module to the command line for worker nodes.

- Fixes: [CASMINST-4884](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4884)
- Requires:
- Relates to: NETETH-1987

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [x] I have included documentation in my PR (or it is not required)
- [x] I tested this on internal system (if yes, please include results or a description of the test)
- [] I tested this on a vshasta system (if yes, please include results or a description of the test)

Tested successfully on redbull.  However, I noticed that it results in this new error during boot:
```
[FAILED] Failed to start Load RDMA …m /etc/rdma/modules/rdma.conf.
```
 
### Idempotency
 
N/A
 
### Risks and Mitigations
 
N/A
