### PR TITLE
CASMINST-4909 Include canu in the rpm output

### DIFF
--- a/bin/metalid.sh
+++ b/bin/metalid.sh
@@ -25,8 +25,10 @@
 # run to completion even if RPMs are missing
 set +e
 
+# Do not include CSI, csi version is invoked to give more specific version information that RPMs do not give.
+RPMS=( "canu" "ilorest" "metal-basecamp" "metal-ipxe" "metal-net-scripts" "pit-init" "pit-nexus" )
 echo '= PIT Identification = COPY/CUT START ======================================='
 cat /etc/pit-release
 csi version
-rpm -q ilorest metal-basecamp metal-ipxe metal-net-scripts pit-init pit-nexus
+rpm -q "${RPMS[@]}"
 echo '= PIT Identification = COPY/CUT END ========================================='


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Relates to: CASMINST-4909

#### Issue Type

<!--- Delete un-needed bullets -->

- RFE Pull Request

<!--- words; describe what this change is and what it is for. -->

`canu` is now included in the `metalid.sh` output.

```bash
= PIT Identification = COPY/CUT START =======================================
VERSION=1.8.0
TIMESTAMP=20220628162838
HASH=ge005460
CRAY-Site-Init build signature...
Build Commit   : caa0690373e6c58b0cd2eff0c9332b182ed27712-heads-v1.20.0
Build Time     : 2022-06-24T23:17:09Z
Go Version     : go1.18
Git Version    : v1.20.0
Platform       : linux/amd64
App. Version   : ..
canu-1.6.5-1.x86_64
ilorest-3.5.1-1.x86_64
metal-basecamp-1.2.0-1.x86_64
metal-ipxe-2.2.7-1~mtl_1657_add_var_to_track_dhcp_nic~20220531135656.8f13925.noarch
metal-net-scripts-0.0.2-1.noarch
pit-init-1.2.29~1~g3c8ffa7-1.noarch
pit-nexus-1.1.4-1.x86_64
= PIT Identification = COPY/CUT END =========================================
```
### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [x] I have included documentation in my PR (or it is not required)
- [x] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!---
    Example:
    
    This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
    is resolved and the overall risk of fatal failures is reduced.
    
    -->
