### PR TITLE
Without .version main shouldn't build stable

### DIFF
--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -1,7 +1,7 @@
 @Library('csm-shared-library') _
 
 def sleVersion = '15.3'
-def isStable = env.TAG_NAME != null || env.BRANCH_NAME == 'main' ? true : false
+def isStable = env.TAG_NAME != null ? true : false
 pipeline {
   agent {
     label "metal-gcp-builder"


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request
- Docs Pull Request
- RFE Pull Request

<!--- words; describe what this change is and what it is for. -->

`main` should not be building stable since we build on git-tags. The main stables have been around for a little bit and have produced these oddball RPMs:

<img width="457" alt="image" src="https://user-images.githubusercontent.com/7772179/177604972-13c6ee78-8f6c-46ab-ae6c-5e4c293213fc.png">

I'm not sure why there's duplicate RPMs, but both the ones with and without the `~` will cease being created with this PR.

I've cleaned up Artifactory prior to making this PR, so those RPMs in this picture with the HASH are no longer there.


### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!---
    Example:
    
    This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
    is resolved and the overall risk of fatal failures is reduced.
    
    -->
