### PR TITLE
CASMINST-5003

### DIFF
--- a/bin/set-sqfs-links.sh
+++ b/bin/set-sqfs-links.sh
@@ -100,6 +100,9 @@ if [ -n "${CSM_RELEASE:-}" ]; then
     fi
     echo -e "\tImages will be stored on the NCN at /run/initramfs/live/$CSM_RELEASE/"
 else
+    if grep -q rd.live.dir /var/www/boot/script.ipxe; then
+        sed -i -E 's/rd.live.dir=.* //g' /var/www/boot/script.ipxe
+    fi
     echo -e >&2 "\tWARNING: CSM_RELEASE was not set, images will be stored in their default location on the node(s) at /run/initramfs/live/LiveOS/"
 fi
 

--- a/bin/set-sqfs-links.sh
+++ b/bin/set-sqfs-links.sh
@@ -93,7 +93,11 @@ echo "$0 is creating boot directories for each NCN with a BMC that has a lease i
 echo -e "\tNOTE: Nodes without boot directories will still boot the non-destructive iPXE binary for bare-metal discovery usage."
 
 if [ -n "${CSM_RELEASE:-}" ]; then
-    sed -i -E 's/live-sqfs-opts root/live-sqfs-opts rd.live.dir='"$CSM_RELEASE"' root/g' /var/www/boot/script.ipxe
+    if grep -q rd.live.dir /var/www/boot/script.ipxe; then
+        sed -i -E 's/rd.live.dir=.* /rd.live.dir='"$CSM_RELEASE"' /g' /var/www/boot/script.ipxe
+    else
+        sed -i -E 's/live-sqfs-opts root/live-sqfs-opts rd.live.dir='"$CSM_RELEASE"' root/g' /var/www/boot/script.ipxe
+    fi
     echo -e "\tImages will be stored on the NCN at /run/initramfs/live/$CSM_RELEASE/"
 else
     echo -e >&2 "\tWARNING: CSM_RELEASE was not set, images will be stored in their default location on the node(s) at /run/initramfs/live/LiveOS/"

--- a/bin/set-sqfs-links.sh
+++ b/bin/set-sqfs-links.sh
@@ -73,6 +73,15 @@ call_bmc || echo no BMC password set, using existing dnsmasq.leases
 
 echo "$0 is creating boot directories for each NCN with a BMC that has a lease in /var/lib/misc/dnsmasq.leases"
 echo "Nodes without boot directories will still boot the non-destructive iPXE binary."
+
+if [ -n "${CSM_RELEASE:-}" ]; then
+    sed -i -E 's/live-sqfs-opts root/live-sqfs-opts rd.live.dir='"$CSM_RELEASE"' root/g' /var/www/boot/script.ipxe
+    echo -e "\tImages will be stored on the NCN at /run/initramfs/live/$CSM_RELEASE/"
+else
+    echo -e >&2 "\tWARNING: CSM_RELEASE was not set, images will be stored in their default location on the node(s) at /run/initramfs/live/LiveOS/"
+fi
+
+
 #shellcheck disable=SC2013
 for ncn in $(grep -Eo 'ncn-[mw]\w+' /var/lib/misc/dnsmasq.leases | sort -u); do
     mkdir -pv ${ncn} && pushd ${ncn}

--- a/bin/set-sqfs-links.sh
+++ b/bin/set-sqfs-links.sh
@@ -24,31 +24,45 @@
 
 #shellcheck disable=SC2086
 
-set -eu
+set -euo pipefail
 
 WEB_ROOT=/var/www
 
 function call_bmc {
+    local actual_bmcs=0
+    local expected_bmcs=0
     local vendor
     local channel=1 # GB & HPE
 
+    expected_bmcs="$(grep -P 'host-record=ncn-\w\d+-mgmt' /etc/dnsmasq.d/statics.conf | grep -v m001 | wc -l)"
     vendor="$(ipmitool fru | awk '/Board Mfg/ && !/Date/ {print $4}')"
     if [[ "$vendor" = *Intel* ]]; then
         channel=3
     fi
 
     [ -z "$IPMI_PASSWORD" ] && echo >&2 'Need IPMI_PASSWORD set in env (export IPMI_PASSWORD=password).' && return 1
-    echo 'Attempting to set all known BMCs (from /etc/conman.conf) to dhcp mode'
+    echo 'Attempting to set all known BMCs (from /etc/conman.conf) to DHCP mode'
     echo "current BMC count: $(grep -c mgmt /var/lib/misc/dnsmasq.leases)"
     (
     export username=root
     export IPMI_PASSWORD=$IPMI_PASSWORD
     grep mgmt /etc/conman.conf | grep -v m001 | awk '{print $3}' | cut -d ':' -f2 | tr -d \" | xargs -t -i ipmitool -I lanplus -U $username -E -H {} lan set $channel ipsrc dhcp
     ) >/var/log/metal-bmc-restore.$$.out 2>&1
-    sleep 2 && echo "new BMC count: $(grep -c mgmt /var/lib/misc/dnsmasq.leases)"
+    function _actual_bmcs {
+        grep -c mgmt /var/lib/misc/dnsmasq.leases
+    }
+    actual_bmcs="$(_actual_bmcs)"
+    while [ ! "$actual_bmcs" -eq "$expected_bmcs" ] ; do
+        echo "Waiting on $expected_bmcs to request DHCP ... "
+        actual_bmcs="$(_actual_bmcs)"
+        echo -ne "Current: $actual_bmcs\033[0K\r"
+        sleep 1
+    done
+    echo "All [$expected_bmcs] expected BMCs have requested DHCP."
 }
 
 # Finds latest of each artifact regardless of subdirectory.
+echo "Resolving images to boot ... "
 k8s_initrd="$(find ${WEB_ROOT}/ephemeral/data/k8s -name "*initrd*" -printf '%T@ %p\n' | sort -n | tail -1 |  cut -f2- -d" ")"
 k8s_kernel="$(find ${WEB_ROOT}/ephemeral/data/k8s -name "*.kernel" -printf '%T@ %p\n' | sort -n | tail -1 |  cut -f2- -d" ")"
 k8s_squashfs="$(find ${WEB_ROOT}/ephemeral/data/k8s -name "*.squashfs" -printf '%T@ %p\n' | sort -n | tail -1 |  cut -f2- -d" ")"
@@ -63,6 +77,9 @@ test -z $k8s_squashfs && echo "ERROR: k8s squashfs not found in ${WEB_ROOT}/ephe
 test -z $ceph_initrd && echo "ERROR: storage initrd not found in ${WEB_ROOT}/ephemeral/data/ceph" >&2 && exit 1
 test -z $ceph_kernel && echo "ERROR: storage kernel not found in ${WEB_ROOT}/ephemeral/data/ceph" >&2 && exit 1
 test -z $ceph_squashfs&& echo "ERROR: storage squasfh not found in ${WEB_ROOT}/ephemeral/data/ceph" >&2 && exit 1
+echo 'Images resolved'
+echo -e "Kubernetes Boot Selection:\n\tkernel: $k8s_kernel\n\tinitrd: $k8s_initrd\n\tsquash: $k8s_squashfs"
+echo -e "Storage Boot Selection:\n\tkernel: $ceph_kernel\n\tinitrd: $ceph_initrd\n\tsquash: $ceph_squashfs"
 
 # RULE! The kernels MUST match; the initrds may be different.
 if [[ "$(basename ${k8s_kernel} | cut -d '-' -f1,2)" != "$(basename ${ceph_kernel} | cut -d '-' -f1,2)" ]]; then
@@ -72,7 +89,8 @@ fi
 call_bmc || echo no BMC password set, using existing dnsmasq.leases
 
 echo "$0 is creating boot directories for each NCN with a BMC that has a lease in /var/lib/misc/dnsmasq.leases"
-echo "Nodes without boot directories will still boot the non-destructive iPXE binary."
+
+echo -e "\tNOTE: Nodes without boot directories will still boot the non-destructive iPXE binary for bare-metal discovery usage."
 
 if [ -n "${CSM_RELEASE:-}" ]; then
     sed -i -E 's/live-sqfs-opts root/live-sqfs-opts rd.live.dir='"$CSM_RELEASE"' root/g' /var/www/boot/script.ipxe
@@ -81,31 +99,38 @@ else
     echo -e >&2 "\tWARNING: CSM_RELEASE was not set, images will be stored in their default location on the node(s) at /run/initramfs/live/LiveOS/"
 fi
 
-
-#shellcheck disable=SC2013
-for ncn in $(grep -Eo 'ncn-[mw]\w+' /var/lib/misc/dnsmasq.leases | sort -u); do
-    mkdir -pv ${ncn} && pushd ${ncn}
-    cp -pv /var/www/boot/script.ipxe .
+readarray -t NCNS_K8S < <(grep -Eo 'ncn-[mw]\w+' /var/lib/misc/dnsmasq.leases | sort -u)
+if [ "${#NCNS_K8S[@]}" = 0 ]; then
+    echo >&2 'No kubernetes NCN BMCs found in /var/lib/misc/dnsmasq.leases'
+    exit 1
+fi
+for ncn in "${NCNS_K8S[@]}"; do
+    mkdir -p ${ncn} && pushd ${ncn} >/dev/null
+    cp -p /var/www/boot/script.ipxe .
     if [[ "$ncn" =~ 'ncn-w' ]]; then
         sed -i -E 's/rd.luks(=1)?\s/rd.luks=0 /g' script.ipxe
     fi
-    ln -vsnf ..${k8s_kernel///var\/www} kernel
-    ln -vsnf ..${k8s_initrd///var\/www} initrd.img.xz
-    ln -vsnf ..${k8s_squashfs///var\/www} filesystem.squashfs
-    popd
+    ln -snf ..${k8s_kernel///var\/www} kernel
+    ln -snf ..${k8s_initrd///var\/www} initrd.img.xz
+    ln -snf ..${k8s_squashfs///var\/www} filesystem.squashfs
+    popd >/dev/null
 done
-#shellcheck disable=SC2013
-for ncn in $(grep -Eo 'ncn-s\w+' /var/lib/misc/dnsmasq.leases | sort -u); do
-    mkdir -pv ${ncn} && pushd ${ncn}
-    cp -pv /var/www/boot/script.ipxe .
-    ln -vsnf ..${ceph_kernel///var\/www} kernel
-    ln -vsnf ..${ceph_initrd///var\/www} initrd.img.xz
-    ln -vsnf ..${ceph_squashfs///var\/www} filesystem.squashfs
-    popd
+readarray -t NCNS_CEPH < <(grep -Eo 'ncn-s\w+' /var/lib/misc/dnsmasq.leases | sort -u)
+if [ "${#NCNS_CEPH[@]}" = 0 ]; then
+    echo >&2 'No storage NCN BMCs found in /var/lib/misc/dnsmasq.leases'
+    exit 1
+fi
+for ncn in "${NCNS_CEPH[@]}"; do
+    mkdir -p ${ncn} && pushd ${ncn} >/dev/null
+    cp -p /var/www/boot/script.ipxe .
+    ln -snf ..${ceph_kernel///var\/www} kernel
+    ln -snf ..${ceph_initrd///var\/www} initrd.img.xz
+    ln -snf ..${ceph_squashfs///var\/www} filesystem.squashfs
+    popd >/dev/null
 done
 
 if ! [ "$(pwd)" = $WEB_ROOT ]; then
-    rsync -rltDvq --remove-source-files ncn-* $WEB_ROOT 2>/dev/null && rmdir ncn-* || echo >&2 'FATAL: No NCN BMCs found in /var/lib/misc/dnsmasq.leases'
+    rsync -rltDvq --remove-source-files ncn-* $WEB_ROOT 2>/dev/null && rmdir ncn-*
 fi
 
-echo 'done'
+echo '/var/www is ready.'

--- a/bin/set-sqfs-links.sh
+++ b/bin/set-sqfs-links.sh
@@ -94,14 +94,14 @@ echo -e "\tNOTE: Nodes without boot directories will still boot the non-destruct
 
 if [ -n "${CSM_RELEASE:-}" ]; then
     if grep -q rd.live.dir /var/www/boot/script.ipxe; then
-        sed -i -E 's/rd.live.dir=.* /rd.live.dir='"$CSM_RELEASE"' /g' /var/www/boot/script.ipxe
+        sed -i -E 's/rd.live.dir=.* root/rd.live.dir='"$CSM_RELEASE"' root/g' /var/www/boot/script.ipxe
     else
         sed -i -E 's/live-sqfs-opts root/live-sqfs-opts rd.live.dir='"$CSM_RELEASE"' root/g' /var/www/boot/script.ipxe
     fi
     echo -e "\tImages will be stored on the NCN at /run/initramfs/live/$CSM_RELEASE/"
 else
     if grep -q rd.live.dir /var/www/boot/script.ipxe; then
-        sed -i -E 's/rd.live.dir=.* //g' /var/www/boot/script.ipxe
+        sed -i -E 's/rd.live.dir=.* root/root/g' /var/www/boot/script.ipxe
     fi
     echo -e >&2 "\tWARNING: CSM_RELEASE was not set, images will be stored in their default location on the node(s) at /run/initramfs/live/LiveOS/"
 fi


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: CASMINST-5003

#### Issue Type

<!--- Delete un-needed bullets -->

- RFE Pull Request

<!--- words; describe what this change is and what it is for. -->

This PR does two things:
1. It implements CASMINST-5003 which will update `script.ipxe` to tell dracut to download the artifacts into a directory named after `CSM_RELEASE` (e.g. `/run/initramfs/live/$CSM_RELEASE`). If `CSM_RELEASE` is not set, then the default directory is used (e.g. `/run/initramfs/live/LiveOS`). This is controlled by setting the `rd.live.dir` argument on the kernel commandline.
2. This tidies the output of the script up and adds some error checking
   - Instead of sleeping for 2 seconds after setting the BMCs to DHCP, the number of actual BMCs that have DHCPed is checked against an expected number. The current count will print into the screen until the actual DHCP BMC count meets the expected number of BMCs.
   - Instead of printing every directory and the content within for each NCN, the targeted artifacts are printed _once_. This makes the output of the script significantly shorter, making it easier to see whether everything worked.
   - This adds `-o pipefail` to ensure commands fail when ran in pipes
   
   Example output when `CSM_RELEASE` is not set:

      ```bash
      redbull-ncn-m001-pit:~ # set-sqfs-links.sh
      Resolving images to boot ...
      Images resolved
      Kubernetes Boot Selection:
              kernel: /var/www/ephemeral/data/k8s/0.3.20-3/5.3.18-150300.59.76-default-0.3.20-3.kernel
              initrd: /var/www/ephemeral/data/k8s/0.3.20-3/initrd.img-0.3.20-3.xz
              squash: /var/www/ephemeral/data/k8s/0.3.20-3/secure-kubernetes-0.3.20-3.squashfs
      Storage Boot Selection:
              kernel: /var/www/ephemeral/data/ceph/0.3.20-3/5.3.18-150300.59.76-default-0.3.20-3.kernel
              initrd: /var/www/ephemeral/data/ceph/0.3.20-3/initrd.img-0.3.20-3.xz
              squash: /var/www/ephemeral/data/ceph/0.3.20-3/secure-storage-ceph-0.3.20-3.squashfs
      Attempting to set all known BMCs (from /etc/conman.conf) to DHCP mode
      current BMC count: 9
      All [9] expected BMCs have requested DHCP.
      /root/bin/set-sqfs-links.sh is creating boot directories for each NCN with a BMC that has a lease in /var/lib/misc/dnsmasq.leases
              NOTE: Nodes without boot directories will still boot the non-destructive iPXE binary for bare-metal discovery usage.
              WARNING: CSM_RELEASE was not set, images will be stored in their default location on the node(s) at /run/initramfs/live/LiveOS/
      /var/www is ready.
      ```

   Example output when `CSM_RELEASE` is set:

      ```bash
      redbull-ncn-m001-pit:~ # export CSM_RELEASE=1.3.0-alpha.18
      redbull-ncn-m001-pit:~ # set-sqfs-links.sh
      Resolving images to boot ...
      Images resolved
      Kubernetes Boot Selection:
              kernel: /var/www/ephemeral/data/k8s/0.3.20-3/5.3.18-150300.59.76-default-0.3.20-3.kernel
              initrd: /var/www/ephemeral/data/k8s/0.3.20-3/initrd.img-0.3.20-3.xz
              squash: /var/www/ephemeral/data/k8s/0.3.20-3/secure-kubernetes-0.3.20-3.squashfs
      Storage Boot Selection:
              kernel: /var/www/ephemeral/data/ceph/0.3.20-3/5.3.18-150300.59.76-default-0.3.20-3.kernel
              initrd: /var/www/ephemeral/data/ceph/0.3.20-3/initrd.img-0.3.20-3.xz
              squash: /var/www/ephemeral/data/ceph/0.3.20-3/secure-storage-ceph-0.3.20-3.squashfs
      Attempting to set all known BMCs (from /etc/conman.conf) to DHCP mode
      current BMC count: 9
      All [9] expected BMCs have requested DHCP.
      /root/bin/set-sqfs-links.sh is creating boot directories for each NCN with a BMC that has a lease in /var/lib/misc/dnsmasq.leases
              NOTE: Nodes without boot directories will still boot the non-destructive iPXE binary for bare-metal discovery usage.
              Images will be stored on the NCN at /run/initramfs/live/1.3.0-alpha.18/
      /var/www is ready.
      ```

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [x] I have included documentation in my PR (or it is not required)
- [x] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
The resulting iPXE script will contain this line, and will only add this line _once_ (so it is idempotent).

```
set live-sqfs-opts rd.live.dir=1.3.0-alpha.18 root=live:LABEL=SQFSRAID rd.live.ram=0 rd.writable.fsimg=0 rd.skipfsck rd.live.squashimg=${image-name}
```

If `CSM_RELEASE` is unset and the script is ran again or if `CSM_RELEASE` was never set, then `rd.live.dir` will not exist on the command line

```
set live-sqfs-opts root=live:LABEL=SQFSRAID rd.live.ram=0 rd.writable.fsimg=0 rd.skipfsck rd.live.squashimg=${image-name}
```

If `CSM_RELEASE` is changed after this script runs, then the line will be updated accordingly.

### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!---
    Example:
    
    This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
    is resolved and the overall risk of fatal failures is reduced.
    
    -->
This mitigates risk by providing cleaner output to the screen, and this facilitates determining which image artifacts are on a system by using `CSM_RELEASE`. More importantly, this ensures that during upgrades artifacts do now download into the same directory and if they have a few name differences that they do not overlap.
