### PR TITLE
MTL-1868 Remove redundant print

### DIFF
--- a/bin/set-sqfs-links.sh
+++ b/bin/set-sqfs-links.sh
@@ -52,8 +52,8 @@ function call_bmc {
         grep -c mgmt /var/lib/misc/dnsmasq.leases
     }
     actual_bmcs="$(_actual_bmcs)"
+    echo "Waiting on $expected_bmcs to request DHCP ... "
     while [ ! "$actual_bmcs" -eq "$expected_bmcs" ] ; do
-        echo "Waiting on $expected_bmcs to request DHCP ... "
         actual_bmcs="$(_actual_bmcs)"
         echo -ne "Current: $actual_bmcs\033[0K\r"
         sleep 1


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: MTL-1868

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->

Removes the redundant printing message "Waiting on 9 to request DHCP ..." seen in the below snippet. Instead it'll be printed once, and then the counter is printed until the number of actuals meets the number of expected.

```bash
redbull-ncn-m001-pit:~ # set-sqfs-links.sh
Resolving images to boot ...
Images resolved
Kubernetes Boot Selection:
        kernel: /var/www/ephemeral/data/k8s/fe775c6-1659395320990/5.3.18-150300.59.76-default-fe775c6-1659395320990.kernel
        initrd: /var/www/ephemeral/data/k8s/fe775c6-1659395320990/initrd.img-fe775c6-1659395320990.xz
        squash: /var/www/ephemeral/data/k8s/fe775c6-1659395320990/secure-kubernetes-fe775c6-1659395320990.squashfs
Storage Boot Selection:
        kernel: /var/www/ephemeral/data/ceph/fe775c6-1659395320990/5.3.18-150300.59.76-default-fe775c6-1659395320990.kernel
        initrd: /var/www/ephemeral/data/ceph/fe775c6-1659395320990/initrd.img-fe775c6-1659395320990.xz
        squash: /var/www/ephemeral/data/ceph/fe775c6-1659395320990/secure-storage-ceph-fe775c6-1659395320990.squashfs
Attempting to set all known BMCs (from /etc/conman.conf) to DHCP mode
current BMC count: 0
Waiting on 9 to request DHCP ...
Waiting on 9 to request DHCP ...
Waiting on 9 to request DHCP ...
All [9] expected BMCs have requested DHCP.
/root/bin/set-sqfs-links.sh is creating boot directories for each NCN with a BMC that has a lease in /var/lib/misc/dnsmasq.leases
        NOTE: Nodes without boot directories will still boot the non-destructive iPXE binary for bare-metal discovery usage.
        WARNING: CSM_RELEASE was not set, images will be stored in their default location on the node(s) at /run/initramfs/live/LiveOS/
/var/www is ready.
```
### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [x] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!---
    Example:
    
    This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
    is resolved and the overall risk of fatal failures is reduced.
    
    -->
