### PR TITLE
CASMINST-5209: Add progress bars to wget invocations

### DIFF
--- a/bin/get-sqfs.sh
+++ b/bin/get-sqfs.sh
@@ -46,7 +46,7 @@ fi
 mkdir -pv /var/www/ephemeral/data/ceph
 pushd /var/www/ephemeral/data/ceph || return
 echo Downloading storage-ceph artifacts ...
-wget --mirror -np -nH --cut-dirs=4 -A *.kernel,*initrd*,*.squashfs -R index.html* -e robots=off -nv https://$ARTIFACTORY_USER:$ARTIFACTORY_TOKEN@artifactory.algol60.net/artifactory/csm-images/${stream}/storage-ceph/${id}/
+wget --progress=bar:force:noscroll -q --show-progress --mirror -np -nH --cut-dirs=4 -A *.kernel,*initrd*,*.squashfs -R index.html* -e robots=off https://$ARTIFACTORY_USER:$ARTIFACTORY_TOKEN@artifactory.algol60.net/artifactory/csm-images/${stream}/storage-ceph/${id}/
 for file in ${id}/storage-ceph*.squashfs; do
     [ ! -f $file ] && echo >&2 Failed to download SquashFS.
 done 
@@ -62,7 +62,7 @@ popd || exit
 mkdir -pv /var/www/ephemeral/data/k8s
 pushd /var/www/ephemeral/data/k8s || return
 echo Downloading kubernetes artifacts ...
-wget --mirror -np -nH --cut-dirs=4 -A *.kernel,*initrd*,*.squashfs -R index.html* -e robots=off -nv https://$ARTIFACTORY_USER:$ARTIFACTORY_TOKEN@artifactory.algol60.net/artifactory/csm-images/${stream}/kubernetes/${id}/
+wget --progress=bar:force:noscroll -q --show-progress --mirror -np -nH --cut-dirs=4 -A *.kernel,*initrd*,*.squashfs -R index.html* -e robots=off https://$ARTIFACTORY_USER:$ARTIFACTORY_TOKEN@artifactory.algol60.net/artifactory/csm-images/${stream}/kubernetes/${id}/
 for file in ${id}/kubernetes*.squashfs; do
     [ ! -f $file ] && echo >&2 Failed to download SquashFS.
 done 


### PR DESCRIPTION
### Summary and Scope

Adds progress bars to get-sqfs.sh script

- Fixes: The ability to know if you can make coffee with an eta on each download
- Requires:
- Relates to:

#### Issue Type

Bug/feature/ish fix

- Bugfix Pull Request
- Docs Pull Request
- RFE Pull Request

<!--- words; describe what this change is and what it is for. -->

### Prerequisites


- [ ] I have included documentation in my PR (or it is not required)
- [ x] I tested this on internal system redbull
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)
 
### Idempotency
 
n/a
 
### Risks and Mitigations
 
n/a just outputs progress bar messages