### PR TITLE
MTL-1876 Use `rootfs`

### DIFF
--- a/bin/set-sqfs-links.sh
+++ b/bin/set-sqfs-links.sh
@@ -76,7 +76,7 @@ test -z $k8s_squashfs && echo "ERROR: k8s squashfs not found in ${WEB_ROOT}/ephe
 
 test -z $ceph_initrd && echo "ERROR: storage initrd not found in ${WEB_ROOT}/ephemeral/data/ceph" >&2 && exit 1
 test -z $ceph_kernel && echo "ERROR: storage kernel not found in ${WEB_ROOT}/ephemeral/data/ceph" >&2 && exit 1
-test -z $ceph_squashfs&& echo "ERROR: storage squasfh not found in ${WEB_ROOT}/ephemeral/data/ceph" >&2 && exit 1
+test -z $ceph_squashfs && echo "ERROR: storage squasfh not found in ${WEB_ROOT}/ephemeral/data/ceph" >&2 && exit 1
 echo 'Images resolved'
 echo -e "Kubernetes Boot Selection:\n\tkernel: $k8s_kernel\n\tinitrd: $k8s_initrd\n\tsquash: $k8s_squashfs"
 echo -e "Storage Boot Selection:\n\tkernel: $ceph_kernel\n\tinitrd: $ceph_initrd\n\tsquash: $ceph_squashfs"
@@ -119,7 +119,7 @@ for ncn in "${NCNS_K8S[@]}"; do
     fi
     ln -snf ..${k8s_kernel///var\/www} kernel
     ln -snf ..${k8s_initrd///var\/www} initrd.img.xz
-    ln -snf ..${k8s_squashfs///var\/www} filesystem.squashfs
+    ln -snf ..${k8s_squashfs///var\/www} rootfs
     popd >/dev/null
 done
 readarray -t NCNS_CEPH < <(grep -Eo 'ncn-s\w+' /var/lib/misc/dnsmasq.leases | sort -u)
@@ -132,7 +132,7 @@ for ncn in "${NCNS_CEPH[@]}"; do
     cp -p /var/www/boot/script.ipxe .
     ln -snf ..${ceph_kernel///var\/www} kernel
     ln -snf ..${ceph_initrd///var\/www} initrd.img.xz
-    ln -snf ..${ceph_squashfs///var\/www} filesystem.squashfs
+    ln -snf ..${ceph_squashfs///var\/www} rootfs
     popd >/dev/null
 done
 


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: MTL-1876
- Relates to: CASMINST-4849

#### Issue Type

<!--- Delete un-needed bullets -->

- RFE Pull Request

<!--- words; describe what this change is and what it is for. -->
To align to what CFS uses, and to make the entire boot process the same for bootstrap, runtime, and customized images (CFS/IMS), we'll use `rootfs` as the filename instead of `filesystem.squashfs`. This will prevent us from needing to fiddle the `rd.live.squashimg` parameter at various points of an install or upgrade.

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!---
    Example:
    
    This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
    is resolved and the overall risk of fatal failures is reduced.
    
    -->
