### PR TITLE
MTL-1952 Fix `csi-setup-lan0.sh` usage

### DIFF
--- a/bin/csi-setup-lan0.sh
+++ b/bin/csi-setup-lan0.sh
@@ -26,7 +26,8 @@ set -eu
 set +x
 if [ $# -lt 2 ]; then
 cat << EOM >&2
-  usage: csi-setup-lan0.sh CIDR|IP/MASQ GATEWAY DEVICE DNS1 DNS2
+  usage: csi-setup-lan0.sh CIDR|IP/MASQ GATEWAY DNS1 DEVICE1 [DEVICE2 DEVICEN]
+         csi-setup-lan0.sh CIDR|IP/MASQ GATEWAY 'DNS1 DNS2 DNSN' DEVICE1 [DEVICE2 DEVICEN]
   i.e.: csi-setup-lan0.sh 172.29.16.5/20 172.29.16.1 172.30.84.40 em1 [em2]
 EOM
   exit 1


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: MTL-1952

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->
Only 1 `DNS` can be defined, unless it uses quotes. Device(s) go last.

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!---
    Example:
    
    This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
    is resolved and the overall risk of fatal failures is reduced.
    
    -->
