### PR TITLE
MTL-1953 Refactor `PIT_DATA` to `PITDATA`

### DIFF
--- a/bin/pit-init.sh
+++ b/bin/pit-init.sh
@@ -57,19 +57,19 @@ function init {
         set +e
         mount -a -v
         set -e
-        PIT_DATA="$(lsblk -o MOUNTPOINT -nr /dev/disk/by-label/PITDATA)"
+        PITDATA="$(lsblk -o MOUNTPOINT -nr /dev/disk/by-label/PITDATA)"
     else
         # PITDATA needs to exist before this script is called, because pit-init relies on items existing
         # within pitdata prior to running it.
         error "No DISK exists for PITDATA"
     fi
 
-    export PREP_DIR=${PIT_DATA}/prep
+    export PREP_DIR=${PITDATA}/prep
     if [ ! -d "$PREP_DIR" ]; then 
         error "$PREP_DIR does not exist! This needs to be created and populated with CSI input files before re-running this script"
     fi
-    export DATA_DIR=${PIT_DATA}/data
-    export CONF_DIR=${PIT_DATA}/configs
+    export DATA_DIR=${PITDATA}/data
+    export CONF_DIR=${PITDATA}/configs
 
     # Create our base directories if they do not already exist.
     if [ ! -d $DATA_DIR ]; then


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: MTL-1953

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->
Fixes incorrect variable usage, preventing an override of `PITDATA` when no partition is used.

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!---
    Example:
    
    This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
    is resolved and the overall risk of fatal failures is reduced.
    
    -->
