### PR TITLE
MTL-1975: don't recursively follow links

### DIFF
--- a/bin/get-sqfs.sh
+++ b/bin/get-sqfs.sh
@@ -46,7 +46,7 @@ fi
 mkdir -pv /var/www/ephemeral/data/ceph
 pushd /var/www/ephemeral/data/ceph || return
 echo Downloading storage-ceph artifacts ...
-wget --progress=bar:force:noscroll -q --show-progress --mirror -np -nH --cut-dirs=4 -A *.kernel,*initrd*,*.squashfs -R index.html* -e robots=off https://$ARTIFACTORY_USER:$ARTIFACTORY_TOKEN@artifactory.algol60.net/artifactory/csm-images/${stream}/storage-ceph/${id}/
+wget --progress=bar:force:noscroll -q --show-progress -r -N -l 1 --no-remove-listing -np -nH --cut-dirs=4 -A *.kernel,*initrd*,*.squashfs -R index.html* -e robots=off https://$ARTIFACTORY_USER:$ARTIFACTORY_TOKEN@artifactory.algol60.net/artifactory/csm-images/${stream}/storage-ceph/${id}/
 for file in ${id}/storage-ceph*.squashfs; do
     [ ! -f $file ] && echo >&2 Failed to download SquashFS.
 done 
@@ -62,7 +62,7 @@ popd || exit
 mkdir -pv /var/www/ephemeral/data/k8s
 pushd /var/www/ephemeral/data/k8s || return
 echo Downloading kubernetes artifacts ...
-wget --progress=bar:force:noscroll -q --show-progress --mirror -np -nH --cut-dirs=4 -A *.kernel,*initrd*,*.squashfs -R index.html* -e robots=off https://$ARTIFACTORY_USER:$ARTIFACTORY_TOKEN@artifactory.algol60.net/artifactory/csm-images/${stream}/kubernetes/${id}/
+wget --progress=bar:force:noscroll -q --show-progress -r -N -l 1 --no-remove-listing -np -nH --cut-dirs=4 -A *.kernel,*initrd*,*.squashfs -R index.html* -e robots=off https://$ARTIFACTORY_USER:$ARTIFACTORY_TOKEN@artifactory.algol60.net/artifactory/csm-images/${stream}/kubernetes/${id}/
 for file in ${id}/kubernetes*.squashfs; do
     [ ! -f $file ] && echo >&2 Failed to download SquashFS.
 done 


### PR DESCRIPTION
### Summary and Scope

With the addition of the 'oval' files, wget wants to read and follow every URL therein. To avoid this, replace `--mirror` with the equivalent command, but only at depth == 1 vs depth == inf.


<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: MTL-1975

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [x] I have included documentation in my PR (or it is not required)
- [x] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!---
    Example:
    
    This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
    is resolved and the overall risk of fatal failures is reduced.
    
    -->
