### PR TITLE
CASMTRIAGE-4671 CASMTRIAGE-4672: nix the ncn-m001 hardcode

### DIFF
--- a/bin/csi-setup-lan0.sh
+++ b/bin/csi-setup-lan0.sh
@@ -66,5 +66,5 @@ wicked ifdown lan0 || err_exit "wicked ifdown lan0 failed"
 wicked ifup lan0 || err_exit "wicked ifup lan0 failed"
 # Shake out daemon handling of new lan0 name.
 systemctl restart wickedd-nanny || err_exit "systemctl restart wickedd-nanny failed"
-hostnamectl set-hostname ${system_name}-ncn-m001-pit || err_exit "hostnamectl set-hostname ${system_name}-pit failed"
+hostnamectl set-hostname ${system_name}-pit || err_exit "hostnamectl set-hostname ${system_name}-pit failed"
 echo


### PR DESCRIPTION
### Summary and Scope

The pit isn't really m001, so stop pretending it is.


<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: CASMTRIAGE-4671 CASMTRIAGE-4672

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [x] I have included documentation in my PR (or it is not required)
- [x] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!---
    Example:
    
    This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
    is resolved and the overall risk of fatal failures is reduced.
    
    -->
