### PR TITLE
CASMMON-208: Automate prometheus, grok exporter and grafana gets instantiated automatically on PIT node.

### DIFF
--- a/bin/pit-init.sh
+++ b/bin/pit-init.sh
@@ -211,6 +211,10 @@ function load_and_start_systemd {
     systemctl enable basecamp dnsmasq nexus
     echo 'Restarting basecamp dnsmasq ... ' && systemctl restart basecamp dnsmasq
     echo 'Restarting nexus ... ' && systemctl restart nexus
+    # Restarting observability services on CSM-PIT
+    systemctl restart grok-exporter.service
+    systemctl restart prometheus.service
+    systemctl restart grafana.service
 }
 
 function main {

--- a/bin/pit-init.sh
+++ b/bin/pit-init.sh
@@ -212,9 +212,8 @@ function load_and_start_systemd {
     echo 'Restarting basecamp dnsmasq ... ' && systemctl restart basecamp dnsmasq
     echo 'Restarting nexus ... ' && systemctl restart nexus
     # Restarting observability services on CSM-PIT
-    systemctl restart grok-exporter.service
-    systemctl restart prometheus.service
-    systemctl restart grafana.service
+    systemctl enable grok-exporter.service prometheus.service grafana.service
+    echo 'Restarting grok-exporter, prometheus grafana' && systemctl restart grok-exporter.service prometheus.service grafana.service
 }
 
 function main {


### PR DESCRIPTION
CASMMON-208: Automate prometheus, grok exporter and grafana gets instantiated automatically on Combined Install Media LiveDVD

## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves - https://jira-pro.its.hpecorp.net:8443/browse/CASMMON-208

## Testing

_List the environments in which these changes were tested._

### Tested on:
Gamora-csm-pit

### Test description:

#### Services:

![image](https://user-images.githubusercontent.com/53111642/207016888-63d58627-8c89-4188-a6d2-4be3a22d12d7.png)

#### Containers

gamora-ncn-m001-pit: # podman ps
CONTAINER ID  IMAGE                                                                                   COMMAND               CREATED        STATUS             PORTS       NAMES
28aa25485756  artifactory.algol60.net/csm-docker/stable/docker.io/grafana/grafana:8.5.9                                     14 hours ago   Up 15 minutes ago              grafana
ce678ff652a4  artifactory.algol60.net/csm-docker/stable/docker.io/grok-exporter/grok-exporter:latest  ./grok_exporter -...  4 minutes ago  Up 2 minutes ago               grok-exporter
a421fc8840a2  artifactory.algol60.net/csm-docker/stable/quay.io/prometheus/prometheus:v2.36.1         --config.file=/et...  4 minutes ago  Up 2 minutes ago               prometheus


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

