### PR TITLE
DVS-2881: Add split_lock_detect=off to ncn-w kernel command line

### DIFF
--- a/bin/set-sqfs-links.sh
+++ b/bin/set-sqfs-links.sh
@@ -116,6 +116,7 @@ for ncn in "${NCNS_K8S[@]}"; do
     cp -p /var/www/boot/script.ipxe .
     if [[ "$ncn" =~ 'ncn-w' ]]; then
         sed -i -E 's/rd.luks(=1)?\s/rd.luks=0 /g' script.ipxe
+        sed -i -E '/ncn-params .*/ s/$/ split_lock_detect=off/' script.ipxe
     fi
     ln -snf ..${k8s_kernel///var\/www} kernel
     ln -snf ..${k8s_initrd///var\/www} initrd.img.xz


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: https://jira-pro.its.hpecorp.net:8443/browse/DVS-2881

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->
Intel has added Split Lock Detection to its 10th generation CPUs and this affects the Castle and Wisteria platforms which will be delivered in the Alice release. The Linux kernel has Split Lock Detect enabled by default, but it can be disabled on a host by adding the kernel parameter, "split_lock_detect=off" to the kernel command line. See https://www.virtualbox.org/ticket/20180 for more detail.

Until we can rewrite the DVS IPC layer we need to add "split_lock_detect=off" to the kernel command line for NCNs and UAN configurations.  This PR covers the NCN-Ws, I have another PR already merged for the UAN.

See https://jira-pro.its.hpecorp.net:8443/browse/DVS-2874 for original crash 
workaround procedure for COS 2.4 https://jira-pro.its.hpecorp.net:8443/browse/DVS-2879

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ x] I have included documentation in my PR (or it is not required)
- [x ] I tested this on internal system (if yes, please include results or a description of the test). I have placed the split_lock_detect=off parameter on the kernel command line and booted systems and that prevents the kernel crash.
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!---
    Example:
    
    This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
    is resolved and the overall risk of fatal failures is reduced.
    
    -->
