### PR TITLE
CASMMON-250 pit-observability

### DIFF
--- a/bin/metalid.sh
+++ b/bin/metalid.sh
@@ -26,7 +26,7 @@
 set +e
 
 # Do not include CSI, csi version is invoked to give more specific version information that RPMs do not give.
-RPMS=( "canu" "ilorest" "metal-basecamp" "metal-ipxe" "metal-net-scripts" "pit-init" "pit-nexus" )
+RPMS=( "canu" "ilorest" "metal-basecamp" "metal-ipxe" "metal-net-scripts" "pit-init" "pit-nexus" "pit-observability" )
 echo '= PIT Identification = COPY/CUT START ======================================='
 cat /etc/pit-release
 csi version

--- a/bin/pit-init.sh
+++ b/bin/pit-init.sh
@@ -211,6 +211,10 @@ function load_and_start_systemd {
     systemctl enable basecamp dnsmasq nexus
     echo 'Restarting basecamp dnsmasq ... ' && systemctl restart basecamp dnsmasq
     echo 'Restarting nexus ... ' && systemctl restart nexus
+    echo 'Starting grok-exporter, prometheus, and grafana'
+    systemctl stop grok-exporter.service prometheus.service grafana.service
+    systemctl enable --now grok-exporter.service prometheus.service grafana.service
+
 }
 
 function main {


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: CASMMON-250
- Requires: https://github.com/Cray-HPE/pit-observability/pull/5
- Relates to: #62 #60 

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->
Do not `restart` the services, they operate with better success if they're `start`ed. This stops them for consistency, and then enables and starts them in one call.

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!---
    Example:
    
    This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
    is resolved and the overall risk of fatal failures is reduced.
    
    -->
