### PR TITLE
MTL-2141

### DIFF
--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -41,7 +41,9 @@ pipeline {
     }
 
     environment {
+        ARCH = 'noarch'
         NAME = getRepoName()
+        PRIMARY_NODE = "${env.NODE_NAME}"
         VERSION = sh(returnStdout: true, script: "git describe --tags | tr -s '-' '~' | sed 's/^v//'").trim()
     }
 
@@ -51,17 +53,15 @@ pipeline {
 
             matrix {
 
-                agent {
-                    node {
-                        label "metal-gcp-builder"
-                        customWorkspace "${env.WORKSPACE}/${sleVersion}"
-                    }
+                environment {
+                    BUILD_DIR = "${env.WORKSPACE}/dist/rpmbuild/${ARCH}/${SLE_VERSION}"
                 }
+
 
                 axes {
                     axis {
-                        name 'sleVersion'
-                        values 15.3, 15.4
+                        name 'SLE_VERSION'
+                        values '15.4', '15.3', '15.2'
                     }
                 }
 
@@ -70,24 +70,27 @@ pipeline {
                     stage('Prepare: RPMs') {
                         agent {
                             docker {
-                                label 'docker'
+                                label "${PRIMARY_NODE}"
                                 reuseNode true
-                                image "${sleImage}:${sleVersion}"
+                                args "-v /home/jenkins/.ssh:/home/jenkins/.ssh"
+                                image "${sleImage}:${SLE_VERSION}"
                             }
                         }
                         steps {
-                            runLibraryScript("addRpmMetaData.sh", "${env.NAME}.spec")
                             sh "make prepare"
-                            sh "git update-index --assume-unchanged ${env.NAME}.spec"
+                            dir("${env.BUILD_DIR}/SPECS/") {
+                                runLibraryScript("addRpmMetaData.sh", "${env.NAME}.spec")
+                            }
                         }
                     }
 
                     stage('Build: RPMs') {
                         agent {
                             docker {
-                                label 'docker'
+                                label "${PRIMARY_NODE}"
                                 reuseNode true
-                                image "${sleImage}:${sleVersion}"
+                                args "-v /home/jenkins/.ssh:/home/jenkins/.ssh"
+                                image "${sleImage}:${SLE_VERSION}"
                             }
                         }
                         steps {
@@ -96,24 +99,33 @@ pipeline {
                     }
 
                     stage('Publish: RPMs') {
+                        agent {
+                            docker {
+                                label "${PRIMARY_NODE}"
+                                reuseNode true
+                                args "-v /home/jenkins/.ssh:/home/jenkins/.ssh"
+                                image "${sleImage}:${SLE_VERSION}"
+                            }
+                        }
                         steps {
                             script {
+                                def sleVersion = sh(returnStdout: true, script: 'awk -F= \'/VERSION_ID/{gsub(/["]/,""); print \$NF}\' /etc/os-release').trim()
                                 def sles_version_parts = "${sleVersion}".tokenize('.')
                                 def sles_major = "${sles_version_parts[0]}"
                                 def sles_minor = "${sles_version_parts[1]}"
                                 publishCsmRpms(
-                                        arch: "noarch",
+                                        arch: "${ARCH}",
                                         component: env.NAME,
                                         isStable: isStable,
                                         os: "sle-${sles_major}sp${sles_minor}",
-                                        pattern: "dist/rpmbuild/RPMS/noarch/*.rpm",
+                                        pattern: "dist/rpmbuild/${ARCH}/${SLE_VERSION}/RPMS/${ARCH}/*.rpm",
                                 )
                                 publishCsmRpms(
                                         arch: "src",
                                         component: env.NAME,
                                         isStable: isStable,
                                         os: "sle-${sles_major}sp${sles_minor}",
-                                        pattern: "dist/rpmbuild/SRPMS/*.rpm",
+                                        pattern: "dist/rpmbuild/${ARCH}/${SLE_VERSION}/SRPMS/*.rpm",
                                 )
                             }
                         }

--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -42,7 +42,7 @@ pipeline {
 
     environment {
         NAME = getRepoName()
-        VERSION = sh(returnStdout: true, script: "git describe --tags | tr -s '-' '~' | tr -d '^v'").trim()
+        VERSION = sh(returnStdout: true, script: "git describe --tags | tr -s '-' '~' | sed 's/^v//'").trim()
     }
 
     stages {

--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,17 @@
 # MIT License
-# 
+#
 # (C) Copyright [2022] Hewlett Packard Enterprise Development LP
-# 
+#
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
 # to deal in the Software without restriction, including without limitation
 # the rights to use, copy, modify, merge, publish, distribute, sublicense,
 # and/or sell copies of the Software, and to permit persons to whom the
 # Software is furnished to do so, subject to the following conditions:
-# 
+#
 # The above copyright notice and this permission notice shall be included
 # in all copies or substantial portions of the Software.
-# 
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
@@ -25,7 +25,7 @@ NAME := $(shell basename $(shell pwd))
 endif
 
 ifeq ($(VERSION),)
-VERSION := $(shell git describe --tags | tr -s '-' '~' | tr -d '^v')
+VERSION := $(shell git describe --tags | tr -s '-' '~' | sed 's/^v//')
 endif
 
 SPEC_FILE ?= ${NAME}.spec

--- a/Makefile
+++ b/Makefile
@@ -28,23 +28,27 @@ ifeq ($(VERSION),)
 VERSION := $(shell git describe --tags | tr -s '-' '~' | sed 's/^v//')
 endif
 
-SPEC_FILE ?= ${NAME}.spec
-SOURCE_NAME ?= ${NAME}
+SPEC_FILE := ${NAME}.spec
+SOURCE_NAME := ${NAME}-${VERSION}
+
 BUILD_DIR ?= $(PWD)/dist/rpmbuild
-SOURCE_PATH := ${BUILD_DIR}/SOURCES/${SOURCE_NAME}-${VERSION}.tar.bz2
+SOURCE_PATH := ${BUILD_DIR}/SOURCES/${SOURCE_NAME}.tar.bz2
 
 rpm: prepare rpm_package_source rpm_build_source rpm_build
 
 prepare:
+	@echo $(NAME)
 	rm -rf $(BUILD_DIR)
 	mkdir -p $(BUILD_DIR)/SPECS $(BUILD_DIR)/SOURCES
 	cp $(SPEC_FILE) $(BUILD_DIR)/SPECS/
 
+# touch the archive before creating it to prevent 'tar: .: file changed as we read it' errors
 rpm_package_source:
-	tar --transform 'flags=r;s,^,/${NAME}-${VERSION}/,' --exclude .git --exclude dist -cvjf $(SOURCE_PATH) .
+	touch $(SOURCE_PATH)
+	tar --transform 'flags=r;s,^,/$(SOURCE_NAME)/,' --exclude .nox --exclude dist/rpmbuild --exclude ${SOURCE_NAME}.tar.bz2 -cvjf $(SOURCE_PATH) .
 
 rpm_build_source:
-	rpmbuild --nodeps -ts $(SOURCE_PATH) --define "_topdir $(BUILD_DIR)"
+	rpmbuild -bs $(BUILD_DIR)/SPECS/$(SPEC_FILE) --define "_topdir $(BUILD_DIR)"
 
 rpm_build:
-	rpmbuild --nodeps -ba $(SPEC_FILE) --define "_topdir $(BUILD_DIR)"
+	rpmbuild -ba $(BUILD_DIR)/SPECS/$(SPEC_FILE) --define "_topdir $(BUILD_DIR)"

--- a/bin/get-sqfs.sh
+++ b/bin/get-sqfs.sh
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -22,55 +22,202 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 
-# usage: get-sqfs.sh 0.0.8
-# usage: get-sqfs.sh 0.0.7
-# usage: get-sqfs.sh f1e225a-1609179792335
-# note: pairs great with set-sqfs-links.sh
+base_url=artifactory.algol60.net/artifactory/csm-images
 
-id=$1
-if [ -z $id ]; then
-    echo >&2 'Missing image ID (e.g. X.Y.Z or COMMIT-TIMESTAMP)'
-    exit 1
-fi
+function usage {
+cat << 'EOF'
+usage:
+
+# Pull 0.0.8 Kubernetes and Storage-CEPH
+get-sqfs.sh 0.0.8
+
+# Pull f1e225a-1609179792335 Kubernetes and Storage-CEPH
+get-sqfs.sh f1e225a-1609179792335
+
+# Pull 0.2.3 Kubernetes and 0.4.3 Storage-CEPH
+get-sqfs.sh -k 0.2.3 -s 0.4.3
+
+# Pull only 0.4.3 Storage-CEPH
+get-sqfs.sh -s 0.4.3
+
+# Pull a pre-install-toolkit ISO
+get-sqfs.sh -p 0.4.3
+
+# Pull using a proxy to download Kubernetes and Storage-CEPH
+get-sqfs.sh -P https://example.proxy.net:443 0.4.3
+
+# Download to a local directory
+get-sqfs.sh -P https://example.proxy.net:443 0.4.3 -d /tmp
+
+EOF
+}
 
 if [ -z "${ARTIFACTORY_USER}" ] || [ -z "${ARTIFACTORY_TOKEN}" ]; then
-    echo >&2 "ARTIFACTORY_USER and ARTIFACTORY_TOKEN must be defined for accessing csm-images in artifactory.algol60.net. One or both were empty/undefined."
+    echo >&2 "ARTIFACTORY_USER and ARTIFACTORY_TOKEN must be defined"
+    echo >&2 "for accessing csm-images in artifactory.algol60.net."
+    echo >&2 "One or both were empty/undefined."
     exit 1
 fi
 
-stream=unstable
-if [[ "$id" =~ [0-9]*\.[0-9]*\.[0-9]*$ ]]; then
-    stream=stable
+ARCH=$(uname -m)
+DEST="/var/www/ephemeral/data"
+use_proxy=no
+http_proxy='null'
+while getopts ":k:H:p:s:a:P:d:" o; do
+    case "${o}" in
+        k)
+            KUBERNETES_ID=${OPTARG}
+            bucket='kubernetes'
+            ;;
+        H)
+            HYPERVISOR_ID=${OPTARG}
+            bucket='hypervisor'
+            ;;
+        p)
+            PRE_INSTALL_TOOLKIT_ID=${OPTARG}
+            bucket='pre-install-toolkit'
+            ;;
+        s)
+            STORAGE_CEPH_ID=${OPTARG}
+            bucket='storage-ceph'
+            ;;
+        a)
+            ARCH=${OPTARG}
+            ;;
+        P)
+            http_proxy=${OPTARG}
+            use_proxy=yes
+            ;;
+        d)
+            DEST=${OPTARG}
+            ;;
+        *)
+            usage
+            ;;
+    esac
+done
+shift $((OPTIND-1))
+
+# By default, if an ID is given without any flags always download the NCN images (kubernetes + storage-ceph).
+if [ -z ${KUBERNETES_ID} ] && [ -z ${STORAGE_CEPH_ID} ] && [ -z ${HYPERVISOR_ID} ] && [ -z ${PRE_INSTALL_TOOLKIT_ID} ]; then
+    if [ -z "${*}" ]; then
+        echo >&2 'Missing image ID (e.g. X.Y.Z or COMMIT-TIMESTAMP)'
+        exit 1
+    fi
+    echo 'Assuming given ID is for Kubernetes and Storage-CEPH'
+    KUBERNETES_ID="${*}"
+    STORAGE_CEPH_ID="${*}"
 fi
 
-mkdir -pv /var/www/ephemeral/data/ceph
-pushd /var/www/ephemeral/data/ceph || return
-echo Downloading storage-ceph artifacts ...
-wget --progress=bar:force:noscroll -q --show-progress -r -N -l 1 --no-remove-listing -np -nH --cut-dirs=4 -A *.kernel,*initrd*,*.squashfs -R index.html* -e robots=off https://$ARTIFACTORY_USER:$ARTIFACTORY_TOKEN@artifactory.algol60.net/artifactory/csm-images/${stream}/storage-ceph/${id}/
-for file in ${id}/storage-ceph*.squashfs; do
-    [ ! -f $file ] && echo >&2 Failed to download SquashFS.
-done 
-for file in ${id}/initrd.img*; do
-    [ ! -f $file ] && echo >&2 Failed to download initrd.img.xz.
-done
-for file in ${id}/*kernel; do
-    [ ! -f $file ] && echo >&2 Failed to download the kernel.
-done 
-ls -l ${id}/
- 
-popd || exit
-mkdir -pv /var/www/ephemeral/data/k8s
-pushd /var/www/ephemeral/data/k8s || return
-echo Downloading kubernetes artifacts ...
-wget --progress=bar:force:noscroll -q --show-progress -r -N -l 1 --no-remove-listing -np -nH --cut-dirs=4 -A *.kernel,*initrd*,*.squashfs -R index.html* -e robots=off https://$ARTIFACTORY_USER:$ARTIFACTORY_TOKEN@artifactory.algol60.net/artifactory/csm-images/${stream}/kubernetes/${id}/
-for file in ${id}/kubernetes*.squashfs; do
-    [ ! -f $file ] && echo >&2 Failed to download SquashFS.
-done 
-for file in ${id}/initrd.img*; do
-    [ ! -f $file ] && echo >&2 Failed to download initrd.img.xz.
-done
-for file in ${id}/*kernel; do
-    [ ! -f $file ] && echo >&2 Failed to download the kernel.
-done 
-ls -l ${id}/ 
-popd || exit
+if [ -n "${STORAGE_CEPH_ID}" ]; then
+    if [ -z "${bucket}" ]; then
+        bucket=storage-ceph
+    fi
+
+    stream=unstable
+    if [[ "$STORAGE_CEPH_ID" =~ [0-9]*\.[0-9]*\.[0-9]*$ ]]; then
+        stream=stable
+    fi
+
+    artifactory_url=https://${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}@${base_url}/${stream}/${bucket}
+    mkdir -pv ${DEST}/ceph
+    pushd ${DEST}/ceph || return
+    echo Downloading ${bucket} artifacts ...
+    wget --progress=bar:force:noscroll -e use_proxy=${use_proxy} -e https_proxy=${http_proxy} -e http_proxy=${http_proxy} -q --show-progress -r -N -l 1 --no-remove-listing -np -nH --cut-dirs=4 -A *.kernel,*initrd*,*.squashfs -R index.html* -e robots=off "${artifactory_url}/${STORAGE_CEPH_ID}/"
+    for file in ${STORAGE_CEPH_ID}/${bucket}*.squashfs; do
+        [ ! -f $file ] && echo >&2 Failed to download SquashFS.
+    done
+    for file in ${STORAGE_CEPH_ID}/initrd.img*; do
+        [ ! -f $file ] && echo >&2 Failed to download initrd.img.xz.
+    done
+    for file in ${STORAGE_CEPH_ID}/*kernel; do
+        [ ! -f $file ] && echo >&2 Failed to download the kernel.
+    done
+    ls -l ${STORAGE_CEPH_ID}/
+    popd || exit
+    unset bucket
+fi
+
+if [ -n "${HYPERVISOR_ID}" ]; then
+    if [ -z "${bucket}" ]; then
+        bucket=hypervisor
+    fi
+
+    stream=unstable
+    if [[ "$HYPERVISOR_ID" =~ [0-9]*\.[0-9]*\.[0-9]*$ ]]; then
+        stream=stable
+    fi
+
+    artifactory_url=https://${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}@${base_url}/${stream}/${bucket}
+    mkdir -pv ${DEST}/${bucket}
+    pushd ${DEST}/${bucket} || return
+    echo Downloading ${bucket} artifacts ...
+    wget --progress=bar:force:noscroll -e use_proxy=${use_proxy} -e https_proxy=${http_proxy} -e http_proxy=${http_proxy} -q --show-progress -r -N -l 1 --no-remove-listing -np -nH --cut-dirs=4 -A *.kernel,*initrd*,*.squashfs,*.iso -R index.html* -e robots=off "${artifactory_url}/${HYPERVISOR_ID}/"
+    for file in ${HYPERVISOR_ID}/${bucket}*.iso; do
+        [ ! -f $file ] && echo >&2 Failed to download ISO.
+    done
+    for file in ${HYPERVISOR_ID}/${bucket}*.squashfs; do
+        [ ! -f $file ] && echo >&2 Failed to download SquashFS.
+    done
+    for file in ${HYPERVISOR_ID}/initrd.img*; do
+        [ ! -f $file ] && echo >&2 Failed to download initrd.img.xz.
+    done
+    for file in ${HYPERVISOR_ID}/*kernel; do
+        [ ! -f $file ] && echo >&2 Failed to download the kernel.
+    done
+    ls -l ${HYPERVISOR_ID}/
+    popd || exit
+    unset bucket
+fi
+
+if [ -n "${KUBERNETES_ID}" ]; then
+    if [ -z "${bucket}" ]; then
+        bucket=kubernetes
+    fi
+
+    stream=unstable
+    if [[ "$KUBERNETES_ID" =~ [0-9]*\.[0-9]*\.[0-9]*$ ]]; then
+        stream=stable
+    fi
+
+    artifactory_url=https://${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}@${base_url}/${stream}/${bucket}
+    mkdir -pv ${DEST}/k8s
+    pushd ${DEST}/k8s || return
+    echo Downloading ${bucket} artifacts ...
+    wget --progress=bar:force:noscroll -e use_proxy=${use_proxy} -e https_proxy=${http_proxy} -e http_proxy=${http_proxy} -q --show-progress -r -N -l 1 --no-remove-listing -np -nH --cut-dirs=4 -A *.kernel,*initrd*,*.squashfs -R index.html* -e robots=off "${artifactory_url}/${KUBERNETES_ID}/"
+    for file in ${KUBERNETES_ID}/${bucket}*.squashfs; do
+        [ ! -f $file ] && echo >&2 Failed to download SquashFS.
+    done
+    for file in ${KUBERNETES_ID}/initrd.img*; do
+        [ ! -f $file ] && echo >&2 Failed to download initrd.img.xz.
+    done
+    for file in ${KUBERNETES_ID}/*kernel; do
+        [ ! -f $file ] && echo >&2 Failed to download the kernel.
+    done
+    ls -l ${KUBERNETES_ID}/
+    popd || exit
+    unset bucket
+fi
+
+if [ -n "${PRE_INSTALL_TOOLKIT_ID}" ]; then
+    if [ -z "${bucket}" ]; then
+        bucket=pre-install-toolkit
+    fi
+
+    stream=unstable
+    if [[ "$PRE_INSTALL_TOOLKIT_ID" =~ [0-9]*\.[0-9]*\.[0-9]*$ ]]; then
+        stream=stable
+    fi
+
+    artifactory_url=https://${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}@${base_url}/${stream}/${bucket}
+    pushd ${DEST} || return
+    echo "Downloading ${bucket} ISO with ID: ${PRE_INSTALL_TOOLKIT_ID}"
+    if [ "${use_proxy}" = 'yes' ]; then
+        curl --proxy ${http_proxy} -C - -f -O "${artifactory_url}/${PRE_INSTALL_TOOLKIT_ID}/${bucket}-${PRE_INSTALL_TOOLKIT_ID}-${ARCH}.iso"
+    else
+        curl -C - -f -O "${artifactory_url}/${PRE_INSTALL_TOOLKIT_ID}/${bucket}-${PRE_INSTALL_TOOLKIT_ID}-${ARCH}.iso"
+    fi
+    [ ! -f ${bucket}-${PRE_INSTALL_TOOLKIT_ID}-${ARCH}.iso ] && echo >&2 "Failed to download ${bucket}-${PRE_INSTALL_TOOLKIT_ID}-${ARCH}.iso"
+    echo "Downloaded ISO to $(pwd)/${bucket}-${PRE_INSTALL_TOOLKIT_ID}-${ARCH}.iso"
+    popd || exit
+fi

--- a/bin/metalid.sh
+++ b/bin/metalid.sh
@@ -26,7 +26,7 @@
 set +e
 
 # Do not include CSI, csi version is invoked to give more specific version information that RPMs do not give.
-RPMS=( "canu" "ilorest" "metal-basecamp" "metal-ipxe" "metal-net-scripts" "pit-init" "pit-nexus" "pit-observability" )
+RPMS=( "canu" "ilorest" "metal-basecamp" "metal-ipxe" "pit-init" "pit-nexus" "pit-observability" )
 echo '= PIT Identification = COPY/CUT START ======================================='
 cat /etc/pit-release
 csi version

--- a/pit-init.spec
+++ b/pit-init.spec
@@ -1,17 +1,17 @@
 # MIT License
-# 
+#
 # (C) Copyright [2021-2022] Hewlett Packard Enterprise Development LP
-# 
+#
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
 # to deal in the Software without restriction, including without limitation
 # the rights to use, copy, modify, merge, publish, distribute, sublicense,
 # and/or sell copies of the Software, and to permit persons to whom the
 # Software is furnished to do so, subject to the following conditions:
-# 
+#
 # The above copyright notice and this permission notice shall be included
 # in all copies or substantial portions of the Software.
-# 
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
@@ -23,7 +23,7 @@
 %define install_dir /root/bin/
 
 Name: %(echo $NAME)
-BuildArch: noarch
+BuildArch: %(echo $ARCH)
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}
 License: HPE Proprietary
 Summary: The pre-install toolkit scripts provided on the CRAY LiveCD


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: MTL-2141
- Relates to: [HPCDC-7633](https://github.hpe.com/hpe/hpc-shasta-system-configs/blob/main/HPCDC-7633-LR1-upgrade.md) (LR1 work)

#### Issue Type

<!--- Delete un-needed bullets -->

- RFE Pull Request

<!--- words; describe what this change is and what it is for. -->
Offers support for HTTP/HTTPS proxies for fetching artifacts.

Also adds:
- support for other artifacts; pre-install-toolkit ISOs, and hypervisor images
- ability to exclusively download Kubernetes or Storage-CEPH, or both

##### Testing with Proxy on redbull

```bash
get-sqfs.sh -P http://hpeproxy.its.hpecorp.net:443/ e3346d4-1683407921384
Assuming given ID is for Kubernetes and Storage-CEPH
/var/www/ephemeral/data/ceph ~
Downloading storage-ceph artifacts ...
e3346d4-1683407921384/index.html.tmp                                       [ <=>                                                                                                                                                                       ]   4.33K  --.-KB/s    in 0s
e3346d4-1683407921384/5.14.21-150400.24.60-default-e3346d4-16834079213 100%[==========================================================================================================================================================================>]  10.92M  8.62MB/s    in 1.3s
e3346d4-1683407921384/initrd.img-e3346d4-1683407921384-x86_64.xz       100%[==========================================================================================================================================================================>]  93.37M  10.9MB/s    in 8.6s
e3346d4-1683407921384/storage-ceph-e3346d4-1683407921384-x86_64.squash  80%[========================================================================================================================================>                                  ]   2.62G  11.0MB/s    eta 72s
```

##### Testing without Proxy on GCP

```bash
root@doomslayer-1337:/home/rusty# ./get-sqfs.sh 0.5.22
Assuming given ID is for Kubernetes and Storage-CEPH
/var/www/ephemeral/data/ceph /home/rusty
Downloading storage-ceph artifacts ...
0.5.22/index.html.tmp                  [ <=>                                                             ]   3.63K  --.-KB/s    in 0s
0.5.22/5.14.21-150400.24.55-defaul 100%[================================================================>]  10.91M  --.-KB/s    in 0.1s
0.5.22/initrd.img-0.5.22-x86_64.xz 100%[================================================================>]  87.17M  98.1MB/s    in 0.9s
0.5.22/storage-ceph-0.5.22-x86_64.  90%[==========================================================>      ]   2.95G  65.5MB/s    eta 5s
```

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [x] I tested this on internal system (if yes, please include results or a description of the test)
- [x] I tested this on a vshasta system (if yes, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!---
    Example:
    
    This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
    is resolved and the overall risk of fatal failures is reduced.
    
    -->
