### PR TITLE
CASMINST-6418: make sure we find an initrd, not an initrd sha file

### DIFF
--- a/bin/set-sqfs-links.sh
+++ b/bin/set-sqfs-links.sh
@@ -63,10 +63,10 @@ function call_bmc {
 
 # Finds latest of each artifact regardless of subdirectory.
 echo "Resolving images to boot ... "
-k8s_initrd="$(find ${WEB_ROOT}/ephemeral/data/k8s -name "initrd*" -printf '%T@ %p\n' | grep -v '.txt' | sort -n | tail -1 |  cut -f2- -d" ")"
+k8s_initrd="$(find ${WEB_ROOT}/ephemeral/data/k8s -name "initrd*.xz" -printf '%T@ %p\n' | grep -v '.txt' | sort -n | tail -1 |  cut -f2- -d" ")"
 k8s_kernel="$(find ${WEB_ROOT}/ephemeral/data/k8s -name "*.kernel" -printf '%T@ %p\n' | sort -n | tail -1 |  cut -f2- -d" ")"
 k8s_squashfs="$(find ${WEB_ROOT}/ephemeral/data/k8s -name "*.squashfs" -printf '%T@ %p\n' | sort -n | tail -1 |  cut -f2- -d" ")"
-ceph_initrd="$(find ${WEB_ROOT}/ephemeral/data/ceph -name "initrd*" -printf '%T@ %p\n' | grep -v '.txt' | sort -n | tail -1 |  cut -f2- -d" ")"
+ceph_initrd="$(find ${WEB_ROOT}/ephemeral/data/ceph -name "initrd*.xz" -printf '%T@ %p\n' | grep -v '.txt' | sort -n | tail -1 |  cut -f2- -d" ")"
 ceph_kernel="$(find ${WEB_ROOT}/ephemeral/data/ceph -name "*.kernel" -printf '%T@ %p\n' | sort -n | tail -1 |  cut -f2- -d" ")"
 ceph_squashfs="$(find ${WEB_ROOT}/ephemeral/data/ceph -name "*.squashfs" -printf '%T@ %p\n' | sort -n | tail -1 |  cut -f2- -d" ")"
 


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: CASMINST-6418

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [x] I have included documentation in my PR (or it is not required)
- [x] I tested this on internal system (if yes, please include results or a description of the test)
- [x] I tested this on a vshasta system (if yes, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!---
    Example:
    
    This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
    is resolved and the overall risk of fatal failures is reduced.
    
    -->
