### PR TITLE
MTL-2000 Invoke `csi patch packages`

### DIFF
--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -26,7 +26,7 @@
 @Library('csm-shared-library') _
 
 def isStable = env.TAG_NAME != null ? true : false
-def sleImage = 'artifactory.algol60.net/csm-docker/stable/csm-docker-sle'
+def sleImage = 'artifactory.algol60.net/csm-docker/stable/csm-docker-sle:latest'
 pipeline {
 
     agent {
@@ -42,94 +42,111 @@ pipeline {
 
     environment {
         ARCH = 'noarch'
+        BUILD_DIR = "${env.WORKSPACE}/dist/rpmbuild/${ARCH}"
         NAME = getRepoName()
         PRIMARY_NODE = "${env.NODE_NAME}"
         VERSION = sh(returnStdout: true, script: "git describe --tags | tr -s '-' '~' | sed 's/^v//'").trim()
     }
-
     stages {
-
-        stage('Build & Publish') {
-
-            matrix {
-
-                environment {
-                    BUILD_DIR = "${env.WORKSPACE}/dist/rpmbuild/${ARCH}/${SLE_VERSION}"
+        stage('Prepare: RPMs') {
+            agent {
+                docker {
+                    label "${PRIMARY_NODE}"
+                    reuseNode true
+                    args "-v /home/jenkins/.ssh:/home/jenkins/.ssh"
+                    image "${sleImage}"
                 }
-
-
-                axes {
-                    axis {
-                        name 'SLE_VERSION'
-                        values '15.4', '15.3', '15.2'
-                    }
+            }
+            steps {
+                sh "make prepare"
+                dir("${env.BUILD_DIR}/SPECS/") {
+                    runLibraryScript("addRpmMetaData.sh", "${env.NAME}.spec")
                 }
+            }
+        }
 
-                stages {
+        stage('Build: RPMs') {
+            agent {
+                docker {
+                    label "${PRIMARY_NODE}"
+                    reuseNode true
+                    args "-v /home/jenkins/.ssh:/home/jenkins/.ssh"
+                    image "${sleImage}"
+                }
+            }
+            steps {
+                sh "make rpm"
+            }
+        }
 
-                    stage('Prepare: RPMs') {
-                        agent {
-                            docker {
-                                label "${PRIMARY_NODE}"
-                                reuseNode true
-                                args "-v /home/jenkins/.ssh:/home/jenkins/.ssh"
-                                image "${sleImage}:${SLE_VERSION}"
-                            }
-                        }
-                        steps {
-                            sh "make prepare"
-                            dir("${env.BUILD_DIR}/SPECS/") {
-                                runLibraryScript("addRpmMetaData.sh", "${env.NAME}.spec")
-                            }
-                        }
-                    }
-
-                    stage('Build: RPMs') {
-                        agent {
-                            docker {
-                                label "${PRIMARY_NODE}"
-                                reuseNode true
-                                args "-v /home/jenkins/.ssh:/home/jenkins/.ssh"
-                                image "${sleImage}:${SLE_VERSION}"
-                            }
-                        }
-                        steps {
-                            sh "make rpm"
-                        }
-                    }
-
-                    stage('Publish: RPMs') {
-                        agent {
-                            docker {
-                                label "${PRIMARY_NODE}"
-                                reuseNode true
-                                args "-v /home/jenkins/.ssh:/home/jenkins/.ssh"
-                                image "${sleImage}:${SLE_VERSION}"
-                            }
-                        }
-                        steps {
-                            script {
-                                def sleVersion = sh(returnStdout: true, script: 'awk -F= \'/VERSION_ID/{gsub(/["]/,""); print \$NF}\' /etc/os-release').trim()
-                                def sles_version_parts = "${sleVersion}".tokenize('.')
-                                def sles_major = "${sles_version_parts[0]}"
-                                def sles_minor = "${sles_version_parts[1]}"
-                                publishCsmRpms(
-                                        arch: "${ARCH}",
-                                        component: env.NAME,
-                                        isStable: isStable,
-                                        os: "sle-${sles_major}sp${sles_minor}",
-                                        pattern: "dist/rpmbuild/${ARCH}/${SLE_VERSION}/RPMS/${ARCH}/*.rpm",
-                                )
-                                publishCsmRpms(
-                                        arch: "src",
-                                        component: env.NAME,
-                                        isStable: isStable,
-                                        os: "sle-${sles_major}sp${sles_minor}",
-                                        pattern: "dist/rpmbuild/${ARCH}/${SLE_VERSION}/SRPMS/*.rpm",
-                                )
-                            }
-                        }
-                    }
+        stage('Publish: RPMs') {
+            agent {
+                docker {
+                    label "${PRIMARY_NODE}"
+                    reuseNode true
+                    args "-v /home/jenkins/.ssh:/home/jenkins/.ssh"
+                    image "${sleImage}"
+                }
+            }
+            steps {
+                script {
+                    publishCsmRpms(
+                            arch: "${ARCH}",
+                            component: env.NAME,
+                            isStable: isStable,
+                            os: "noos",
+                            pattern: "dist/rpmbuild/${ARCH}/RPMS/${ARCH}/*.rpm",
+                    )
+                    publishCsmRpms(
+                            arch: "src",
+                            component: env.NAME,
+                            isStable: isStable,
+                            os: "noos",
+                            pattern: "dist/rpmbuild/${ARCH}/SRPMS/*.rpm",
+                    )
+                    // TODO: Remove all of the following publish calls once we are comfortable using noos.
+                    publishCsmRpms(
+                            arch: "${ARCH}",
+                            component: env.NAME,
+                            isStable: isStable,
+                            os: "sle-15sp4",
+                            pattern: "dist/rpmbuild/${ARCH}/RPMS/${ARCH}/*.rpm",
+                    )
+                    publishCsmRpms(
+                            arch: "src",
+                            component: env.NAME,
+                            isStable: isStable,
+                            os: "sle-15sp4",
+                            pattern: "dist/rpmbuild/${ARCH}/SRPMS/*.rpm",
+                    )
+                    publishCsmRpms(
+                            arch: "${ARCH}",
+                            component: env.NAME,
+                            isStable: isStable,
+                            os: "sle-15sp3",
+                            pattern: "dist/rpmbuild/${ARCH}/RPMS/${ARCH}/*.rpm",
+                    )
+                    publishCsmRpms(
+                            arch: "src",
+                            component: env.NAME,
+                            isStable: isStable,
+                            os: "sle-15sp3",
+                            pattern: "dist/rpmbuild/${ARCH}/SRPMS/*.rpm",
+                    )
+                    publishCsmRpms(
+                            arch: "${ARCH}",
+                            component: env.NAME,
+                            isStable: isStable,
+                            os: "sle-15sp2",
+                            pattern: "dist/rpmbuild/${ARCH}/RPMS/${ARCH}/*.rpm",
+                    )
+                    publishCsmRpms(
+                            arch: "src",
+                            component: env.NAME,
+                            isStable: isStable,
+                            os: "sle-15sp2",
+                            pattern: "dist/rpmbuild/${ARCH}/SRPMS/*.rpm",
+                    )
                 }
             }
         }


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->
 
- Fixes: MTL-2000
- Relates to: MTL-2032

#### Issue Type

<!--- Delete un-needed bullets -->

- RFE Pull Request

<!--- words; describe what this change is and what it is for. -->
`csi patch packages` is a new command from MTL-2000 that will patch a given `cloud-init.yaml` file into `data.json`. The intention here is that `cloud-init.yaml` contains a list of `repos` and `packages` that we want cloud-init to install when it runs on the deployed nodes.

If the `cloud-init.yaml` file does not exist in the tar ball, and none is provided on the command line, then this step is skipped. Additionally, if `csi patch packages` is not available then the step is skipped.

Lastly this adds some skip options and a usage for `pit-init.sh`.

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [x] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)
 

If the installed version of `cray-site-init` does not have `csi patch packages` the script will continue with an info message:
```
The installed version of CSI does not have the `csi patch packages` command. data.json will not be patched with packages and repository manifests.
```

### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!---
    Example:
    
    This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
    is resolved and the overall risk of fatal failures is reduced.
    
    -->
